### PR TITLE
Switch main gruvbox link to community edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Palette
 
 ## Ports
 
-Here's a list of ports to other text editors and applications. The original Vim theme can be found here: https://github.com/morhetz/gruvbox
+Here's a list of ports to other text editors and applications. The original Vim theme can be found here: https://github.com/gruvbox-community/gruvbox
 
 ### Alacritty
 


### PR DESCRIPTION
Since this is the community edition of gruvbox, reference that version as the main project, instead of the original.