### PR TITLE
Correct gruvbox-dark-hard iTerm2 scheme

### DIFF
--- a/iterm2/gruvbox-dark-hard.itermcolors
+++ b/iterm2/gruvbox-dark-hard.itermcolors
@@ -7,13 +7,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.15686270594596863</real>
+		<real>0.12941177189350128</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.15686270594596863</real>
+		<real>0.12549020349979401</real>
 		<key>Red Component</key>
-		<real>0.15686273574829102</real>
+		<real>0.11372549086809158</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
@@ -280,13 +280,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.15686270594596863</real>
+		<real>0.12941177189350128</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.15686270594596863</real>
+		<real>0.12549020349979401</real>
 		<key>Red Component</key>
-		<real>0.15686273574829102</real>
+		<real>0.11372549086809158</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>


### PR DESCRIPTION
In the "gruvbox-dark-hard" iTerm2 colorscheme the black and 'cursor text' colors are wrong: they maintain the same value as the medium contrast theme (#282828) while they should be #1d2021, as indicated by morhetz himself: https://github.com/morhetz/gruvbox-contrib/issues/17