### PR TITLE
Update iterm colors using latest hex codes

### DIFF
--- a/iterm2/gruvbox-dark.itermcolors
+++ b/iterm2/gruvbox-dark.itermcolors
@@ -7,245 +7,245 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.11759774386882782</real>
+		<real>0.15686275064945221</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.11759573966264725</real>
+		<real>0.15686275064945221</real>
 		<key>Red Component</key>
-		<real>0.11759927868843079</real>
+		<real>0.15686275064945221</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.090684391558170319</real>
+		<real>0.11372549086809158</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.05879192054271698</real>
+		<real>0.14117647707462311</real>
 		<key>Red Component</key>
-		<real>0.74529051780700684</real>
+		<real>0.80000001192092896</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.11661489307880402</real>
+		<real>0.14901961386203766</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.69061970710754395</real>
+		<real>0.73333334922790527</real>
 		<key>Red Component</key>
-		<real>0.66574931144714355</real>
+		<real>0.72156864404678345</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.1444794088602066</real>
+		<real>0.18431372940540314</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.6926688551902771</real>
+		<real>0.74117648601531982</real>
 		<key>Red Component</key>
-		<real>0.96949708461761475</real>
+		<real>0.98039215803146362</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.52537077665328979</real>
+		<real>0.59607845544815063</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.58534377813339233</real>
+		<real>0.64705884456634521</real>
 		<key>Red Component</key>
-		<real>0.44289660453796387</real>
+		<real>0.51372551918029785</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.53848373889923096</real>
+		<real>0.60784316062927246</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.43883562088012695</real>
+		<real>0.52549022436141968</real>
 		<key>Red Component</key>
-		<real>0.78096956014633179</real>
+		<real>0.82745099067687988</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.41142863035202026</real>
+		<real>0.48627451062202454</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.71257460117340088</real>
+		<real>0.75294119119644165</real>
 		<key>Red Component</key>
-		<real>0.49072420597076416</real>
+		<real>0.55686277151107788</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.63873869180679321</real>
+		<real>0.69803923368453979</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.82989895343780518</real>
+		<real>0.85882353782653809</real>
 		<key>Red Component</key>
-		<real>0.90061241388320923</real>
+		<real>0.92156863212585449</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.082894742488861084</real>
+		<real>0.10196078568696976</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.53061914443969727</real>
+		<real>0.59215688705444336</real>
 		<key>Red Component</key>
-		<real>0.52591603994369507</real>
+		<real>0.59607845544815063</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.10328958928585052</real>
+		<real>0.12941177189350128</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.53254079818725586</real>
+		<real>0.60000002384185791</real>
 		<key>Red Component</key>
-		<real>0.80126690864562988</real>
+		<real>0.84313726425170898</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4586675763130188</real>
+		<real>0.53333336114883423</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.45008346438407898</real>
+		<real>0.5215686559677124</real>
 		<key>Red Component</key>
-		<real>0.21694663166999817</real>
+		<real>0.27058824896812439</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.45103743672370911</real>
+		<real>0.52549022436141968</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.29604318737983704</real>
+		<real>0.38431373238563538</real>
 		<key>Red Component</key>
-		<real>0.62685638666152954</real>
+		<real>0.69411766529083252</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.34128850698471069</real>
+		<real>0.41568627953529358</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.55607825517654419</real>
+		<real>0.61568629741668701</real>
 		<key>Red Component</key>
-		<real>0.34054014086723328</real>
+		<real>0.40784314274787903</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.44320183992385864</real>
+		<real>0.51764708757400513</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.5310559868812561</real>
+		<real>0.60000002384185791</real>
 		<key>Red Component</key>
-		<real>0.5926094651222229</real>
+		<real>0.65882354974746704</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.37962067127227783</real>
+		<real>0.45490196347236633</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.43934443593025208</real>
+		<real>0.51372551918029785</real>
 		<key>Red Component</key>
-		<real>0.49889594316482544</real>
+		<real>0.57254904508590698</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.15763583779335022</real>
+		<real>0.20392157137393951</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.18880486488342285</real>
+		<real>0.28627452254295349</real>
 		<key>Red Component</key>
-		<real>0.96744710206985474</real>
+		<real>0.9843137264251709</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.11759774386882782</real>
+		<real>0.15686275064945221</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.11759573966264725</real>
+		<real>0.15686275064945221</real>
 		<key>Red Component</key>
-		<real>0.11759927868843079</real>
+		<real>0.15686275064945221</real>
 	</dict>
 	<key>Badge Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>0.5</real>
 		<key>Blue Component</key>
-		<real>0.056549370288848877</real>
+		<real>0.054901961237192154</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.28100395202636719</real>
+		<real>0.364705890417099</real>
 		<key>Red Component</key>
-		<real>0.7928692102432251</real>
+		<real>0.83921569585800171</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.99999994039535522</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>1</real>
+		<real>0.99999994039535522</real>
 		<key>Red Component</key>
 		<real>1</real>
 	</dict>
@@ -254,91 +254,91 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.63873869180679321</real>
+		<real>0.69803923368453979</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.82989895343780518</real>
+		<real>0.85882353782653809</real>
 		<key>Red Component</key>
-		<real>0.90061241388320923</real>
+		<real>0.92156863212585449</real>
 	</dict>
 	<key>Cursor Guide Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.15993706881999969</real>
+		<real>0.21176470816135406</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.16613791882991791</real>
+		<real>0.21960784494876862</real>
 		<key>Red Component</key>
-		<real>0.17867125570774078</real>
+		<real>0.23529411852359772</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.11759774386882782</real>
+		<real>0.15686275064945221</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.11759573966264725</real>
+		<real>0.15686275064945221</real>
 		<key>Red Component</key>
-		<real>0.11759927868843079</real>
+		<real>0.15686275064945221</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.63873869180679321</real>
+		<real>0.69803923368453979</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.82989895343780518</real>
+		<real>0.85882353782653809</real>
 		<key>Red Component</key>
-		<real>0.90061241388320923</real>
+		<real>0.92156863212585449</real>
 	</dict>
 	<key>Link Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.056549370288848877</real>
+		<real>0.054901961237192154</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.28100395202636719</real>
+		<real>0.364705890417099</real>
 		<key>Red Component</key>
-		<real>0.7928692102432251</real>
+		<real>0.83921569585800171</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.26041668653488159</real>
+		<real>0.32941177487373352</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.2891082763671875</real>
+		<real>0.36078432202339172</real>
 		<key>Red Component</key>
-		<real>0.32501408457756042</real>
+		<real>0.40000000596046448</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.63873869180679321</real>
+		<real>0.69803923368453979</real>
 		<key>Color Space</key>
-		<string>Calibrated</string>
+		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.82989895343780518</real>
+		<real>0.85882353782653809</real>
 		<key>Red Component</key>
-		<real>0.90061241388320923</real>
+		<real>0.92156863212585449</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
When I imported the file `/iterm2/gruvbox-dark.itermcolors`, the hex codes showing up in the iTerm2 profile panel didn't match up with the hex codes on the gruvbox-community/gruvbox repo. This PR fixes that.